### PR TITLE
CSRF Removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ List all movies
 Look a movie up by `title`
 - `POST /rentals/:title/check-out`  
 Check out one of the movie's inventory to the customer. The rental's check-out date should be set to today.
-- `POST /rentals/:title/check-in`  
+- `POST /rentals/:title/return`  
 Check in one of a customer's rentals
 - `GET /rentals/overdue`  
 List all customers with overdue movies

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
+  #protect_from_forgery with: :exception
 end


### PR DESCRIPTION
Just removing the check for the Cross Site Forgery cookie, since we're not using web forms and everything comes from external addresses.

Also found a bug when checking out & In videos (the returned field was `nil` instead of `false`.

Lastly found a typo in the README since the returned route is `/return` and not `/check-in`